### PR TITLE
Fixes #24 - Handles templates in package installs

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+graft shoki/templates

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ README = (HERE / "README.md").read_text()
 # This call to setup() does all the work
 setup(
     name='shoki',
-    version='2.0.0',
+    version='2.0.2',
     description='Generate minutes from a text file',
     long_description=README,
     long_description_content_type='text/markdown',

--- a/shoki/formatter.py
+++ b/shoki/formatter.py
@@ -10,6 +10,7 @@ import os
 from string import Template
 import sys
 
+from pkg_resources import resource_filename
 from shoki import shoki_config
 
 
@@ -78,7 +79,7 @@ def load_templates(out_format):
 
     If the output format doesn't exist. It returns None.
     """
-    templates_dir = os.path.join(shoki_config.ROOT, "shoki/templates/", out_format)
+    templates_dir = os.path.join(resource_filename('shoki', 'templates'), out_format)
     if os.path.isdir(templates_dir):
         t = {}
         for tmpl_name in os.listdir(templates_dir):
@@ -88,4 +89,6 @@ def load_templates(out_format):
                 tmpl = Template(f.read())
             t[tmpl_key] = tmpl
         return t
+    else:
+        print("{tmpldir} doesn't exist!".format(tmpldir=templates_dir))
     return None


### PR DESCRIPTION
The script where dependent of understanding the local templates.
This adds the templates to the distribution
and make them reachable once packaged.